### PR TITLE
Apple OAuth 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,13 +23,16 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
 	implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
-	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'mysql:mysql-connector-java'
+	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation('org.springframework.boot:spring-boot-starter-test') {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
 	}
 	compile group: 'com.github.ulisesbocchio', name: 'jasypt-spring-boot-starter', version: '3.0.2'
+	compile 'io.jsonwebtoken:jjwt-api:0.11.1'
+	runtime 'io.jsonwebtoken:jjwt-impl:0.11.1',
+			'io.jsonwebtoken:jjwt-jackson:0.11.1'
 }
 
 test {

--- a/src/main/java/com/poogle/phog/common/AuthCheckInterceptor.java
+++ b/src/main/java/com/poogle/phog/common/AuthCheckInterceptor.java
@@ -1,0 +1,37 @@
+package com.poogle.phog.common;
+
+import com.poogle.phog.domain.User;
+import com.poogle.phog.domain.UserRepository;
+import com.poogle.phog.exception.AuthorizationException;
+import com.poogle.phog.service.JwtService;
+import org.omg.CosNaming.NamingContextPackage.NotFound;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Map;
+
+public class AuthCheckInterceptor implements HandlerInterceptor {
+    private final String HEADER_AUTH = "Authorization";
+    private final JwtService jwtService;
+    private final UserRepository userRepository;
+
+    public AuthCheckInterceptor(JwtService jwtService, UserRepository userRepository) {
+        this.jwtService = jwtService;
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
+                             Object handler) throws Exception {
+        String jwt = request.getHeader(HEADER_AUTH);
+        if (jwt == null) {
+            throw AuthorizationException.emptyToken();
+        }
+        Map<String, Object> payloads = jwtService.getTokenPayload(jwt);
+        String socialId = jwtService.parseAppleJwt(payloads).getSocialId();
+        User user = userRepository.findUserBySocialId(socialId).orElseThrow(NotFound::new);
+        request.setAttribute("id", user.getId());
+        return true;
+    }
+}

--- a/src/main/java/com/poogle/phog/common/WebMvcConfig.java
+++ b/src/main/java/com/poogle/phog/common/WebMvcConfig.java
@@ -1,0 +1,33 @@
+package com.poogle.phog.common;
+
+import com.poogle.phog.domain.UserRepository;
+import com.poogle.phog.service.JwtService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    JwtService jwtService;
+    UserRepository userRepository;
+
+    public WebMvcConfig(JwtService jwtService, UserRepository userRepository) {
+        this.jwtService = jwtService;
+        this.userRepository = userRepository;
+    }
+
+    @Bean
+    public AuthCheckInterceptor authCheckInterceptor() {
+        return new AuthCheckInterceptor(jwtService, userRepository);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authCheckInterceptor())
+                .addPathPatterns("/**")
+                .excludePathPatterns("/apple-login")
+                .excludePathPatterns("/mock/**");
+    }
+}

--- a/src/main/java/com/poogle/phog/domain/User.java
+++ b/src/main/java/com/poogle/phog/domain/User.java
@@ -1,0 +1,30 @@
+package com.poogle.phog.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Setter
+@ToString
+@Getter
+@Builder
+@Entity
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+    private String name;
+    private String socialId;
+    private String email;
+
+    protected User() {
+
+    }
+}

--- a/src/main/java/com/poogle/phog/domain/UserRepository.java
+++ b/src/main/java/com/poogle/phog/domain/UserRepository.java
@@ -1,0 +1,9 @@
+package com.poogle.phog.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findUserBySocialId(String socialId);
+}

--- a/src/main/java/com/poogle/phog/exception/AuthorizationException.java
+++ b/src/main/java/com/poogle/phog/exception/AuthorizationException.java
@@ -1,0 +1,16 @@
+package com.poogle.phog.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
+public class AuthorizationException extends RuntimeException {
+
+    public static AuthorizationException emptyToken() {
+        return new AuthorizationException("Token doesn't exist");
+    }
+
+    public AuthorizationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/poogle/phog/service/JwtService.java
+++ b/src/main/java/com/poogle/phog/service/JwtService.java
@@ -1,0 +1,57 @@
+package com.poogle.phog.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.poogle.phog.domain.User;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
+
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class JwtService {
+
+    private final String APPLE_KEY;
+    private final String APPLE_ID;
+
+    public JwtService(Environment env) {
+        APPLE_KEY = env.getProperty("APPLE_KEY");
+        APPLE_ID = env.getProperty("APPLE_ID");
+    }
+
+    public Map<String, Object> getTokenPayload(String jwt) {
+        Map<String, Object> payloadMap = new HashMap<>();
+        ObjectMapper om = new ObjectMapper();
+        String encodedTokenPayload = jwt.split("\\.")[1];
+        Base64.Decoder decoder = Base64.getDecoder();
+        String tokenPayload = new String(decoder.decode(encodedTokenPayload));
+        try {
+            payloadMap = om.readValue(tokenPayload, new TypeReference<Map<String, Object>>() {
+            });
+        } catch (Exception e) {
+            System.out.println("[getTokenPayLoad] " + e.getMessage());
+        }
+        return payloadMap;
+    }
+
+    public boolean checkAppleValidation(Map<String, Object> payloads) {
+        //APPLE_KEY
+        String registeredKey = (String) payloads.get("iss");
+        //APPLE_ID
+        String account = (String) payloads.get("aud");
+        return (registeredKey.equals(APPLE_KEY) && account.equals(APPLE_ID));
+    }
+
+    public User parseAppleJwt(Map<String, Object> payloads) {
+        String socialId = (String) payloads.get("socialId");
+        String name = (String) payloads.get("name");
+        String email = (String) payloads.get("email");
+        return User.builder()
+                .name(name)
+                .socialId(socialId)
+                .email(email)
+                .build();
+    }
+}

--- a/src/main/java/com/poogle/phog/service/UserService.java
+++ b/src/main/java/com/poogle/phog/service/UserService.java
@@ -1,0 +1,28 @@
+package com.poogle.phog.service;
+
+import com.poogle.phog.domain.User;
+import com.poogle.phog.domain.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public void insertOrUpdate(User user) {
+        Optional<User> currentUser = userRepository.findUserBySocialId(user.getSocialId());
+        if (currentUser.isPresent()) {
+            currentUser.get().setName(user.getName());
+            currentUser.get().setEmail(user.getEmail());
+            userRepository.save(currentUser.get());
+        } else {
+            userRepository.save(user);
+        }
+    }
+}

--- a/src/main/java/com/poogle/phog/web/login/controller/LoginController.java
+++ b/src/main/java/com/poogle/phog/web/login/controller/LoginController.java
@@ -1,0 +1,38 @@
+package com.poogle.phog.web.login.controller;
+
+import com.poogle.phog.domain.User;
+import com.poogle.phog.service.JwtService;
+import com.poogle.phog.service.UserService;
+import com.poogle.phog.web.login.dto.PostRequestDTO;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletResponse;
+import java.util.Map;
+
+@RestController
+public class LoginController {
+
+    private final JwtService jwtService;
+    private final UserService userService;
+
+    public LoginController(JwtService jwtService, UserService userService) {
+        this.jwtService = jwtService;
+        this.userService = userService;
+    }
+
+    @PostMapping("/apple-login")
+    public void appleLogin(@RequestBody PostRequestDTO postRequestDTO,
+                           HttpServletResponse response) {
+        Map<String, Object> payloads = jwtService.getTokenPayload(postRequestDTO.getJwtToken());
+        if (!jwtService.checkAppleValidation(payloads)) {
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            return;
+        }
+        User user = jwtService.parseAppleJwt(payloads);
+        userService.insertOrUpdate(user);
+        response.setStatus(HttpStatus.OK.value());
+    }
+}

--- a/src/main/java/com/poogle/phog/web/login/dto/PostRequestDTO.java
+++ b/src/main/java/com/poogle/phog/web/login/dto/PostRequestDTO.java
@@ -1,0 +1,13 @@
+package com.poogle.phog.web.login.dto;
+
+import lombok.*;
+
+@ToString
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostRequestDTO {
+
+    private String jwtToken;
+}


### PR DESCRIPTION
* POST 요청으로 jwtToken을 request body에 담아서 전달 받음
* token의 payload를 복호화하고 Validation을 검증한다.
* payload를 파싱해서 유저 정보를 저장한다.
* AuthCheckInterceptor에 preHandle 구현해 모든 요청 가로채서 토큰 유효성을 검사한다.
    * mock, login 엔드포인트는 제외

---
* iOS 개발에서 OAuth 구현이 나중에 있을 예정이라 deploy가 아닌 dev 브랜치에 우선 pull request를 보내고 merge한다.
* Spring Security로 Session을 사용해 Google OAuth를 추후에 구현할 예정이다.

Close #9 