### PR TITLE
중복 태그 생성을 방지하는 로직 메서드로 추출

### DIFF
--- a/src/main/java/com/poogle/phog/web/note/controller/NoteController.java
+++ b/src/main/java/com/poogle/phog/web/note/controller/NoteController.java
@@ -23,7 +23,6 @@ public class NoteController {
         this.noteService = noteService;
     }
 
-    //TODO: `@RequestAttribute`로 userId 추가
     @PostMapping("")
     public void create(@RequestBody PostNoteRequestDTO request, @RequestAttribute("id") Long userId,
                        HttpServletResponse response) {


### PR DESCRIPTION
* 중복 태그 생성을 방지하는 로직을 따로 추출해서 메서드로 구현한다.
* 그 외 필요 없는 주석들도 지운다.

Issue #28