### PR TITLE
feat: 태그 카테고리(Tags) API 구현

### DIFF
--- a/src/main/java/com/poogle/phog/domain/NoteRepository.java
+++ b/src/main/java/com/poogle/phog/domain/NoteRepository.java
@@ -1,8 +1,15 @@
 package com.poogle.phog.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface NoteRepository extends JpaRepository<Note, Long> {
+
+    @Query(value = "SELECT url FROM Photo WHERE note_id = :id")
+    List<Photo> findPhotoByNoteId(@Param("id") Long noteId);
 }

--- a/src/main/java/com/poogle/phog/domain/NoteTagRepository.java
+++ b/src/main/java/com/poogle/phog/domain/NoteTagRepository.java
@@ -17,4 +17,8 @@ public interface NoteTagRepository extends JpaRepository<NoteTag, Long> {
 
     @Query(value = "SELECT COUNT (note_tag_id) FROM NoteTag WHERE tag_id = :id")
     int countNoteTagByTagId(@Param("id") Long tagId);
+
+    @Query(value = "SELECT MAX(note_id) FROM note_tag WHERE tag_id = :id", nativeQuery=true)
+    Long findRecentNoteIdByTagId(@Param("id") Long tagId);
+
 }

--- a/src/main/java/com/poogle/phog/domain/TagRepository.java
+++ b/src/main/java/com/poogle/phog/domain/TagRepository.java
@@ -1,5 +1,7 @@
 package com.poogle.phog.domain;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,6 +10,10 @@ import java.util.List;
 @Repository
 public interface TagRepository extends JpaRepository<Tag, Long> {
     List<Tag> findTagsByUserIdAndTagNameIn(Long userId, List<String> tags);
+
     List<Tag> findTagsByUserIdAndActivatedTrueOrderByTagNameAsc(Long userId);
+
     List<Tag> findTagsByUserIdAndActivatedFalseOrderByTagNameAsc(Long userId);
+
+    Page<Tag> findAllByUserIdAndActivatedTrue(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/poogle/phog/mock/MockTagController.java
+++ b/src/main/java/com/poogle/phog/mock/MockTagController.java
@@ -2,60 +2,20 @@ package com.poogle.phog.mock;
 
 import com.poogle.phog.web.note.dto.GetNoteResponseDTO;
 import com.poogle.phog.web.photo.dto.GetPhotoResponseDTO;
-import com.poogle.phog.web.tag.dto.GetTagCategoryResponseDTO;
-import com.poogle.phog.web.tag.dto.TagListDTO;
 import com.poogle.phog.web.tag.dto.GetTagSuggestionDTO;
-import com.poogle.phog.web.tag.dto.PatchTagRequestDTO;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
+import com.poogle.phog.web.tag.dto.TagListDTO;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-import javax.servlet.http.HttpServletResponse;
 import java.util.ArrayList;
 import java.util.List;
 
 @RequestMapping("/mock/tags")
 @RestController
 public class MockTagController {
-
-    @GetMapping("/explore")
-    public List<GetTagCategoryResponseDTO> tagCategoryList(
-            @RequestParam(value = "limit", defaultValue = "12") int limit,
-            @RequestParam(value = "offset", defaultValue = "0") int offset) {
-        List<GetTagCategoryResponseDTO> getTagCategoryResponseDTOList = new ArrayList<>();
-        List<GetPhotoResponseDTO> photos = new ArrayList<>();
-        photos.add(GetPhotoResponseDTO.builder()
-                .url("sdfsdsdfsdfsdfsdfsdfsdfsdgdfgfsdf")
-                .build());
-        photos.add(GetPhotoResponseDTO.builder()
-                .url("asdafghfghfghfhgwerwerwerwerwsdf")
-                .build());
-        photos.add(GetPhotoResponseDTO.builder()
-                .url("werrtyytrywerwerwerwerwerwerwqweqfdgfghjkdfvghjrt")
-                .build());
-        getTagCategoryResponseDTOList.add(GetTagCategoryResponseDTO.builder()
-                .tagId(3L)
-                .tagName("#ootd")
-                .frequency(4)
-                .activated(true)
-                .thumbnail(photos.get(1).getUrl())
-                .build());
-        getTagCategoryResponseDTOList.add(GetTagCategoryResponseDTO.builder()
-                .tagId(2L)
-                .tagName("#shopping")
-                .frequency(6)
-                .activated(true)
-                .thumbnail(photos.get(1).getUrl())
-                .build());
-        getTagCategoryResponseDTOList.add(GetTagCategoryResponseDTO.builder()
-                .tagId(5L)
-                .tagName("#달리기")
-                .frequency(6)
-                .activated(true)
-                .thumbnail(photos.get(1).getUrl())
-                .build());
-        return getTagCategoryResponseDTOList;
-    }
-
+    
     @GetMapping("")
     public List<GetNoteResponseDTO> taggedNotes(
             @RequestParam(value = "tag", defaultValue = "1") int tagId) {

--- a/src/main/java/com/poogle/phog/service/TagService.java
+++ b/src/main/java/com/poogle/phog/service/TagService.java
@@ -1,13 +1,14 @@
 package com.poogle.phog.service;
 
-import com.poogle.phog.domain.NoteTagRepository;
-import com.poogle.phog.domain.Tag;
-import com.poogle.phog.domain.TagRepository;
+import com.poogle.phog.domain.*;
+import com.poogle.phog.web.tag.dto.GetTagCategoryResponseDTO;
 import com.poogle.phog.web.tag.dto.GetTagListResponseDTO;
 import com.poogle.phog.web.tag.dto.PatchTagRequestDTO;
 import com.poogle.phog.web.tag.dto.TagListDTO;
 import lombok.extern.slf4j.Slf4j;
 import org.omg.CosNaming.NamingContextPackage.NotFound;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -19,10 +20,12 @@ public class TagService {
 
     private TagRepository tagRepository;
     private NoteTagRepository noteTagRepository;
+    private NoteRepository noteRepository;
 
-    public TagService(TagRepository tagRepository, NoteTagRepository noteTagRepository) {
+    public TagService(TagRepository tagRepository, NoteTagRepository noteTagRepository, NoteRepository noteRepository) {
         this.tagRepository = tagRepository;
         this.noteTagRepository = noteTagRepository;
+        this.noteRepository = noteRepository;
     }
 
     public GetTagListResponseDTO tagResponseDTOList(Long userId) {
@@ -56,5 +59,22 @@ public class TagService {
         Tag tag = tagRepository.findById(tagId).orElseThrow(NotFound::new);
         tag.setActivated(request.getActivated());
         tagRepository.save(tag);
+    }
+
+    public List<GetTagCategoryResponseDTO> tagCategoryResponseDTOList(Long userId, Pageable pageable) {
+        List<GetTagCategoryResponseDTO> getCategorizedTags = new ArrayList<>();
+        Page<Tag> tags = tagRepository.findAllByUserIdAndActivatedTrue(userId, pageable);
+        for (Tag tag : tags) {
+            List<Photo> photoList = noteRepository.findPhotoByNoteId(noteTagRepository.findRecentNoteIdByTagId(tag.getTagId()));
+            GetTagCategoryResponseDTO getTagCategoryResponseDTO = GetTagCategoryResponseDTO.builder()
+                    .tagId(tag.getTagId())
+                    .tagName(tag.getTagName())
+                    .activated(tag.getActivated())
+                    .frequency(noteTagRepository.countNoteTagByTagId(tag.getTagId()))
+                    .thumbnail(photoList.get(0).getUrl())
+                    .build();
+            getCategorizedTags.add(getTagCategoryResponseDTO);
+        }
+        return getCategorizedTags;
     }
 }

--- a/src/main/java/com/poogle/phog/web/tag/controller/TagController.java
+++ b/src/main/java/com/poogle/phog/web/tag/controller/TagController.java
@@ -1,14 +1,17 @@
 package com.poogle.phog.web.tag.controller;
 
 import com.poogle.phog.service.TagService;
+import com.poogle.phog.web.tag.dto.GetTagCategoryResponseDTO;
 import com.poogle.phog.web.tag.dto.GetTagListResponseDTO;
 import com.poogle.phog.web.tag.dto.PatchTagRequestDTO;
 import lombok.extern.slf4j.Slf4j;
 import org.omg.CosNaming.NamingContextPackage.NotFound;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletResponse;
+import java.util.List;
 
 @Slf4j
 @RequestMapping("/tags")
@@ -32,5 +35,11 @@ public class TagController {
                          HttpServletResponse response) throws NotFound {
         tagService.changeActiveStatus(tagId, request);
         response.setStatus(HttpStatus.OK.value());
+    }
+
+    @GetMapping("/explore")
+    public List<GetTagCategoryResponseDTO> categorize(
+            @RequestAttribute("id") Long userId, final Pageable pageable) {
+        return tagService.tagCategoryResponseDTOList(userId, pageable);
     }
 }

--- a/src/main/java/com/poogle/phog/web/tag/dto/GetTagCategoryResponseDTO.java
+++ b/src/main/java/com/poogle/phog/web/tag/dto/GetTagCategoryResponseDTO.java
@@ -3,12 +3,9 @@ package com.poogle.phog.web.tag.dto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
 
-import java.util.List;
-
 @ToString
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Getter
 public class GetTagCategoryResponseDTO {
     private Long tagId;
@@ -16,4 +13,13 @@ public class GetTagCategoryResponseDTO {
     private Integer frequency;
     private Boolean activated;
     private String thumbnail;
+
+    @Builder
+    public GetTagCategoryResponseDTO(Long tagId, String tagName, Integer frequency, Boolean activated, String thumbnail) {
+        this.tagId = tagId;
+        this.tagName = tagName;
+        this.frequency = frequency;
+        this.activated = activated;
+        this.thumbnail = thumbnail;
+    }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -2,8 +2,6 @@ INSERT INTO user (email, name, social_id)
 VALUES ("poogle@mail.com", "poogle", 123456);
 INSERT INTO user (email, name, social_id)
 VALUES ("suhyun@mail.com", "suhyun", 654987);
-INSERT INTO user (email, name, social_id)
-VALUES ("lena@lena.com", "lena", 1442341);
 
 INSERT INTO tag (tag_name, activated, user_id)
 VALUES ("ootd", TRUE, 1);
@@ -25,16 +23,6 @@ INSERT INTO tag (tag_name, activated, user_id)
 VALUES ("운동", TRUE, 2);
 INSERT INTO tag (tag_name, activated, user_id)
 VALUES ("ootd", TRUE, 2);
--- INSERT INTO tag (tag_name, activated, user_id)
--- VALUES ("존맛", TRUE, 4);
--- INSERT INTO tag (tag_name, activated, user_id)
--- VALUES ("Flex", TRUE, 4);
--- INSERT INTO tag (tag_name, activated, user_id)
--- VALUES ("운동", TRUE, 4);
--- INSERT INTO tag (tag_name, activated, user_id)
--- VALUES ("ootd", TRUE, 4);
--- INSERT INTO tag (tag_name, activated, user_id)
--- VALUES ("shopping", TRUE, 4);
 
 INSERT INTO note (created, is_deleted, raw_memo, user_id)
 VALUES ("2020-06-19 13:34:11", FALSE, "Today I had a great lunch. #Flex #존맛", 1);
@@ -46,14 +34,7 @@ INSERT INTO note (created, is_deleted, raw_memo, user_id)
 VALUES ("2020-10-20 11:20:30", FALSE, "#ootd #shopping #Flex", 2);
 INSERT INTO note (created, is_deleted, raw_memo, user_id)
 VALUES ("2020-10-31 08:34:10", FALSE, "#운동 열심히 합시다. #ootd", 2);
--- INSERT INTO note (created, is_deleted, raw_memo, user_id)
--- VALUES ("2020-07-22 16:21:34", FALSE, "Happy Birthday #Flex #존맛", 4);
--- INSERT INTO note (created, is_deleted, raw_memo, user_id)
--- VALUES ("2020-10-20 11:20:30", FALSE, "#ootd #shopping #Flex", 4);
--- INSERT INTO note (created, is_deleted, raw_memo, user_id)
--- VALUES ("2020-10-31 08:34:10", FALSE, "#운동 열심히 합시다. #ootd", 4);
 
---
 INSERT INTO note_tag (note_id, tag_id) VALUES (1, 4);
 INSERT INTO note_tag (note_id, tag_id) VALUES (1, 6);
 INSERT INTO note_tag (note_id, tag_id) VALUES (2, 3);
@@ -66,11 +47,3 @@ INSERT INTO note_tag (note_id, tag_id) VALUES (4, 2);
 INSERT INTO note_tag (note_id, tag_id) VALUES (4, 8);
 INSERT INTO note_tag (note_id, tag_id) VALUES (5, 9);
 INSERT INTO note_tag (note_id, tag_id) VALUES (5, 10);
--- INSERT INTO note_tag (note_id, tag_id) VALUES (6, 11);
--- INSERT INTO note_tag (note_id, tag_id) VALUES (6, 12);
--- INSERT INTO note_tag (note_id, tag_id) VALUES (7, 12);
--- INSERT INTO note_tag (note_id, tag_id) VALUES (7, 14);
--- INSERT INTO note_tag (note_id, tag_id) VALUES (7, 15);
--- INSERT INTO note_tag (note_id, tag_id) VALUES (8, 14);
--- INSERT INTO note_tag (note_id, tag_id) VALUES (8, 14);
-


### PR DESCRIPTION
### 구현 내용
* 태그 카테고리 구현
    * 썸네일 사진: 해당 태그를 가장 최근에 사용한 노트의 첫번째 사진
    * Pagination: 12개씩 무한 스크롤
    * tagName 순 정렬 (A-ㅎ)
    * 해당 태그가 사용된 빈도 표시

Close #21 