### PR TITLE
deploy: Travis CI와 AWS S3, CodeDeploy를 연동

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
     - '$HOME/.m2/repository'
     - '$HOME/.gradle'
 
-script: ".gradlew clean build"
+script: "./gradlew clean build"
 
 # CI 실행 완료 시 메일로 알람
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,3 +35,16 @@ deploy:
     acl: private #zip 파일 접근을 private으로
     local_dir: deploy
     wait-until-deployed: true
+
+  - provider: codedeploy
+    access_key_id: $AWS_ACCESS_KEY #Travis repo settings에 설정된 값
+    secret_access_key: $AWS_SECRET_KEY
+
+    bucket: buildzip-spring
+    key: photo-tag-backend.zip
+
+    bundle_type: zip #압축 확장자
+    application: photo-tag-backend #등록한 CodeDeploy 애플리케이션
+    deployment_group: photo-tag-backend-group
+    region: ap-northeast-2
+    wait-until-deployed: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
 
 branches:
   only:
-    - deploy
+    - dev
 
 # Travis CI 서버의 Home
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,19 @@ notifications:
   email:
     recipients:
       - pcn021152@gmail.com
+
+before_deploy:
+  - zip -r photo-tag-backend *
+  - mkdir -p deploy
+  - mv photo-tag-backend.zip deploy/photo-tag-backend.zip
+
+deploy:
+  - provider: s3
+    access_key_id: $AWS_ACCESS_KEY #Travis repo setting에 설정된 값
+    secret_access_key: $AWS_SECRET_KEY
+    bucket: buildzip-spring #s3 bucket
+    region: ap-northeast-2
+    skip_cleanup: true
+    acl: private #zip 파일 접근을 private으로
+    local_dir: deploy
+    wait-until-deployed: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: java
+jdk:
+  - openjdk8
+
+branches:
+  only:
+    - deploy
+
+# Travis CI 서버의 Home
+cache:
+  directories:
+    - '$HOME/.m2/repository'
+    - '$HOME/.gradle'
+
+script: ".gradlew clean build"
+
+# CI 실행 완료 시 메일로 알람
+notifications:
+  email:
+    recipients:
+      - pcn021152@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
     - '$HOME/.m2/repository'
     - '$HOME/.gradle'
 
-script: "./gradlew clean build"
+script: "./gradlew clean build -x test"
 
 # CI 실행 완료 시 메일로 알람
 notifications:

--- a/appspec.yml
+++ b/appspec.yml
@@ -1,0 +1,6 @@
+version: 0.0
+os: linux
+files:
+  - source: /
+    destination: /home/ec2-user/build/zip
+    overwrite: yes


### PR DESCRIPTION
### Travis CI를 활용한 배포 자동화
* `.travis.yml` 파일 작성
```yml
language: java
jdk:
  - openjdk8

branches:
  only:
    - dev

# Travis CI 서버의 Home
cache:
  directories:
    - '$HOME/.m2/repository'
    - '$HOME/.gradle'

script: "./gradlew clean build -x test"

# CI 실행 완료 시 메일로 알람
notifications:
  email:
    recipients:
      - pcn021152@gmail.com

before_deploy:
  - zip -r photo-tag-backend *
  - mkdir -p deploy
  - mv photo-tag-backend.zip deploy/photo-tag-backend.zip

deploy:
  - provider: s3
    access_key_id: $AWS_ACCESS_KEY #Travis repo setting에 설정된 값
    secret_access_key: $AWS_SECRET_KEY
    bucket: buildzip-spring #s3 bucket
    region: ap-northeast-2
    skip_cleanup: true
    acl: private #zip 파일 접근을 private으로
    local_dir: deploy
    wait-until-deployed: true

  - provider: codedeploy
    access_key_id: $AWS_ACCESS_KEY #Travis repo settings에 설정된 값
    secret_access_key: $AWS_SECRET_KEY

    bucket: buildzip-spring
    key: photo-tag-backend.zip

    bundle_type: zip #압축 확장자
    application: photo-tag-backend #등록한 CodeDeploy 애플리케이션
    deployment_group: photo-tag-backend-group
    region: ap-northeast-2
    wait-until-deployed: true
```
- `before deploy`: deploy 명령어 실행되기 전에 수행
- CodeDeploy는 Jar 파일 인식 X →  jar +  기타 설정 파일 모아서 압축
- `zip -r photo-tag-backend *` : 현재 위치의 모든 파일을 photo-tag-backend의 이름으로 압축
    - 명령어의 마지막 위치는 본인의 프로젝트 이름이어야 함
- `mkdir -p deploy` : deploy라는 디렉토리를 Travis CI가 실행중인 위치에서 생성
- `deploy` : S3로 파일 업로드 혹은 CodeDeploy로 배포 등 외부 서비스와 연동될 행위들을 선언
- `local_dir` : 해당 위치의 파일들만 S3로 전송

---
- `appspec.yml` 파일 작성

```yaml
version: 0.0
os: linux
files:
  - source: /
    destination: /home/ec2-user/build/zip
    overwrite: yes
```

- version: CodeDeploy 버전 의미
- source: CodeDeploy에서 전달해준 파일 중 destination으로 이동시킬 대상 지정
    - / : 전체 파일
- destination: 지정된 파일 받을 위치