### PR TITLE
deploy: NGINX 무중단 배포

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -12,7 +12,13 @@ permissions:
     group: ec2-user
 
 hooks:
-  ApplicationStart:
-    - location: scripts/deploy.sh
+  AfterInstall:
+    - location: scripts/stop.sh #NGINX와 연결되어 있지 않은 스프링 부트를 종료
       timeout: 60
       runas: ec2-user
+  ApplicationStart:
+    - location: scripts/start.sh #NGINX와 연결되어 있지 않은 Port로 새 버전의 스프링 부트를 시작
+      timeout: 60
+      runas: ec2-user
+  ValidateService:
+    - location: scripts/health.sh # 새 스프링 부트가 정상적으로 실행됐는지 확인

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	testImplementation('org.springframework.boot:spring-boot-starter-test') {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
 	}
+	testCompile group: 'junit', name: 'junit', version: '4.12'
 	compile group: 'com.github.ulisesbocchio', name: 'jasypt-spring-boot-starter', version: '3.0.2'
 	compile 'io.jsonwebtoken:jjwt-api:0.11.1'
 	runtime 'io.jsonwebtoken:jjwt-impl:0.11.1',

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.poogle'
-version = '0.0.1-SNAPSHOT'
+version = '1.0.1-SNAPSHOT-'+new Date().format("yyyyMMddHHmmss")
 sourceCompatibility = '1.8'
 
 configurations {

--- a/scripts/health.sh
+++ b/scripts/health.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+ABSPATH=$(readlink -f $0)
+ABSDIR=$(dirname $ABSPATH)
+source ${ABSDIR}/profile.sh
+source ${ABSDIR}/switch.sh
+
+IDLE_PORT=$(find_idle_port)
+
+echo "> Health Check Start"
+echo "> IDLE_PORT: $IDLE_PORT"
+echo "> curl -s http://localhost:$IDLE_PORT/profile "
+sleep 10
+
+for RETRY_COUNT in {1..10}
+do
+  RESPONSE=$(curl -s http://localhost:${IDLE_PORT}/profile)
+  UP_COUNT=$(echo ${RESPONSE} | grep 'deploy' | wc -l)
+
+  if [ ${UP_COUNT} -ge 1 ]
+  then # $up_count >= 1 (deploy 문자열 있는지 검증)
+    echo "> Health check 성공"
+    switch_proxy
+    break
+  else
+    echo "> Health check의 응답을 알 수 없거나 혹은 실행 상태가 아닙니다."
+    echo "> Health check: ${RESPONSE}"
+  fi
+
+  if [ ${RETRY_COUNT} -eq 10 ]
+  then
+    echo "> Health check 실패"
+    echo "> NGINX 연결하지 않고 배포 종료"
+    exit 1
+  fi
+
+  echo "> Health check 연결 실패. 재시도..."
+  sleep 10
+done

--- a/scripts/profile.sh
+++ b/scripts/profile.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# 쉬고 있는 profile 찾기: deploy1 사용중 -> deploy2 쉬는중
+function find_idle_profile() {
+  RESPONSE_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost/profile)
+
+  if [ ${RESPONSE_CODE} -ge 400 ] # 400보다 크면 => 40x, 50x
+  then
+    CURRENT_PROFILE=deploy2
+  else
+    CURRENT_PROFILE=$(curl -s http://localhost/profile)
+  fi
+
+  if [ ${CURRENT_PROFILE} == deploy1 ]
+  then
+    IDLE_PROFILE=deploy2
+  else
+    IDLE_PROFILE=deploy1
+  fi
+
+  echo "${IDLE_PROFILE}"
+}
+
+# 쉬고 있는 profile port 찾기
+function find_idle_port() {
+    IDLE_PROFILE=$(find_idle_profile)
+
+    if [ ${IDLE_PROFILE} == deploy1 ]
+    then
+      echo "8081"
+    else
+      echo "8082"
+    fi
+}

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+ABSPATH=$(readlink -f $0)
+ABSDIR=$(dirname $ABSPATH)
+source ${ABSDIR}/profile.sh
+
+REPOSITORY=/home/ec2-user/app/photo-tag-backend
+PROJECT_NAME=phog
+
+echo "> Build 파일 복사"
+echo "> cp $REPOSITORY/zip/build/libs/*.jar $REPOSITORY/jar/"
+cp $REPOSITORY/zip/build/libs/*.jar $REPOSITORY/jar/
+
+echo "> 새 어플리케이션 배포"
+
+JAR_NAME=$(ls -tr $REPOSITORY/jar/*.jar | tail -n 1)
+
+echo "> JAR Name: $JAR_NAME"
+
+echo "> JAR_NAME에 실행권한 추가"
+
+chmod +x $JAR_NAME
+
+echo "> $JAR_NAME 실행"
+
+echo "> $JAR_NAME을 profile=$IDLE_PROFILE로 실행"
+nohup java -jar \
+    -Dspring.config.location=classpath:/application.properties,classpath:/application-$IDLE_PROFILE.properties \
+    -Dspring.profiles.active=$IDLE_PROFILE \
+    $JAR_NAME > $REPOSITORY/nohup.out 2>&1 &

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+ABSPATH=$(readlink -f $0)
+ABSDIR=$(dirname $ABSPATH)
+source ${ABSDIR}/profile.sh
+
+IDLE_PORT=$(find_idle_port)
+
+echo "> $IDLE_PORT 에서 구동중인 애플리케이션 pid 확인"
+IDLE_PID=$(lsof -ti tcp:${IDLE_PORT})
+
+if [ -z ${IDLE_PID} ]
+then
+  echo "> 현재 구동 중인 애플리케이션이 없으므로 종료하지 않습니다."
+else
+  echo "> kill -15 $IDLE_PID"
+  kill -15 ${IDLE_PID}
+  sleep 5
+fi

--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+ABSPATH=$(readlink -f $0)
+ABSDIR=$(dirname $ABSPATH)
+source ${ABSDIR}/profile.sh
+
+function switch_proxy() {
+  IDLE_PORT=$(find_idle_port)
+
+  echo "> 전환할 port: $IDLE_PORT"
+  echo "> port 전환"
+  echo "set \$service_url http://127.0.0.1:${IDLE_PORT};" | sudo tee /etc/nginx/conf.d/service-url.inc
+
+  echo "> nginx Reload"
+  sudo service nginx reload
+}

--- a/src/main/java/com/poogle/phog/common/WebMvcConfig.java
+++ b/src/main/java/com/poogle/phog/common/WebMvcConfig.java
@@ -32,6 +32,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
                 .excludePathPatterns("/swagger-ui.html")
                 .excludePathPatterns("/swagger-resources/**")
                 .excludePathPatterns("/v2/api-docs")
-                .excludePathPatterns("/webjars/**");
+                .excludePathPatterns("/webjars/**")
+                .excludePathPatterns("/profile");
     }
 }

--- a/src/main/java/com/poogle/phog/web/profile/controller/ProfileController.java
+++ b/src/main/java/com/poogle/phog/web/profile/controller/ProfileController.java
@@ -1,0 +1,26 @@
+package com.poogle.phog.web.profile.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.env.Environment;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Arrays;
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+public class ProfileController {
+    private final Environment env;
+
+    @GetMapping("/profile")
+    public String profile() {
+        List<String> profiles = Arrays.asList(env.getActiveProfiles());
+        List<String> deployProfiles = Arrays.asList("deploy", "deploy1", "deploy2");
+        String defaultProfile = profiles.isEmpty() ? "default" : profiles.get(0);
+        return profiles.stream()
+                .filter(deployProfiles::contains)
+                .findAny()
+                .orElse(defaultProfile);
+    }
+}

--- a/src/main/resources/application-deploy1.properties
+++ b/src/main/resources/application-deploy1.properties
@@ -1,0 +1,3 @@
+server.port=8081
+spring.profiles.include=deploy
+spring.session.store-type=jdbc

--- a/src/main/resources/application-deploy2.properties
+++ b/src/main/resources/application-deploy2.properties
@@ -1,0 +1,3 @@
+server.port=8082
+spring.profiles.include=deploy
+spring.session.store-type=jdbc

--- a/src/test/java/com/poogle/phog/web/profile/controller/ProfileControllerUnitTest.java
+++ b/src/test/java/com/poogle/phog/web/profile/controller/ProfileControllerUnitTest.java
@@ -1,0 +1,59 @@
+package com.poogle.phog.web.profile.controller;
+
+import org.junit.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProfileControllerUnitTest {
+
+    @Test
+    public void deploy_profile이_조회된다() {
+        //given
+        String expectedProfile = "deploy";
+        MockEnvironment env = new MockEnvironment();
+        env.addActiveProfile(expectedProfile);
+        env.addActiveProfile("oauth");
+        env.addActiveProfile("real-db");
+
+        ProfileController controller = new ProfileController(env);
+
+        //when
+        String profile = controller.profile();
+
+        //then
+        assertThat(profile).isEqualTo(expectedProfile);
+    }
+
+    @Test
+    public void deploy_profile이_없으면_첫_번째가_조회된다() {
+        //given
+        String expactedProfile = "oauth";
+        MockEnvironment env = new MockEnvironment();
+
+        env.addActiveProfile(expactedProfile);
+        env.addActiveProfile("real");
+
+        ProfileController controller = new ProfileController(env);
+
+        //when
+        String profile = controller.profile();
+
+        //then
+        assertThat(profile).isEqualTo(expactedProfile);
+    }
+
+    @Test
+    public void active_profile이_없으면_default가_조회된다() {
+        //given
+        String expectedProfile = "default";
+        MockEnvironment env = new MockEnvironment();
+        ProfileController controller = new ProfileController(env);
+
+        //when
+        String profile = controller.profile();
+
+        //then
+        assertThat(profile).isEqualTo(expectedProfile);
+    }
+}


### PR DESCRIPTION
![File (1)](https://user-images.githubusercontent.com/58318786/103284783-8c1bb600-4a1f-11eb-9a4b-ad6425a4cfe5.jpg)

###  NGINX 설치 후 Spring boot 연동
* 포트 포워딩
* ProfileController API 추가
* 테스트 코드 작성
* Profile 생성 (deploy1, deploy2)
* 배포 스크립트 작성
  - `stop.sh`: 기존 NGINX에 연결되어 있진 않지만, 실행중이던 스프링 부트 종료
  - `start.sh`: 배포할 신규 버전 스프링 프로젝트를 `stop.sh`로 종료한 `profile` 로 실행
  - `health.sh`: `start.sh`로 실행시킨 프로젝트가 정상적으로 실행됐는지 체크
  - `switch.sh`: NGINX가 바라보는 스프링 부트를 최신 버전으로 변경
  - `profile.sh`: 앞선 4개 스크립트 파일에서 공용으로 사용할 `profile` 과 포트 체크 로직

* 배포 버전값 자동 변경 위해 코드 추가

Closes #38