### PR TITLE
태그 별 노트 목록 (#TagName) API 구현

### DIFF
--- a/src/main/java/com/poogle/phog/domain/NoteTag.java
+++ b/src/main/java/com/poogle/phog/domain/NoteTag.java
@@ -1,10 +1,12 @@
 package com.poogle.phog.domain;
 
 import lombok.Builder;
+import lombok.Getter;
 import lombok.ToString;
 
 import javax.persistence.*;
 
+@Getter
 @ToString(exclude = {"note", "tag"})
 @Entity
 public class NoteTag {

--- a/src/main/java/com/poogle/phog/domain/NoteTagRepository.java
+++ b/src/main/java/com/poogle/phog/domain/NoteTagRepository.java
@@ -18,7 +18,10 @@ public interface NoteTagRepository extends JpaRepository<NoteTag, Long> {
     @Query(value = "SELECT COUNT (note_tag_id) FROM NoteTag WHERE tag_id = :id")
     int countNoteTagByTagId(@Param("id") Long tagId);
 
-    @Query(value = "SELECT MAX(note_id) FROM note_tag WHERE tag_id = :id", nativeQuery=true)
+    @Query(value = "SELECT MAX(note_id) FROM note_tag WHERE tag_id = :id", nativeQuery = true)
     Long findRecentNoteIdByTagId(@Param("id") Long tagId);
+
+    @Query(value = "SELECT note_id FROM note_tag WHERE tag_id = :id", nativeQuery = true)
+    List<Long> findNoteIdsByTagId(@Param("id") Long tagId);
 
 }

--- a/src/main/java/com/poogle/phog/service/TagService.java
+++ b/src/main/java/com/poogle/phog/service/TagService.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 
 @Slf4j
@@ -93,7 +92,6 @@ public class TagService {
                 }
             }
         }
-        taggedNoteIds.sort(Comparator.reverseOrder());
         List<GetNoteResponseDTO> taggedNotes = new ArrayList<>();
         for (Long noteId : taggedNoteIds) {
             Note note = noteService.findNote(noteId);

--- a/src/main/java/com/poogle/phog/web/note/dto/GetNoteResponseDTO.java
+++ b/src/main/java/com/poogle/phog/web/note/dto/GetNoteResponseDTO.java
@@ -1,19 +1,32 @@
 package com.poogle.phog.web.note.dto;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
-@Setter
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class GetNoteResponseDTO {
+public class GetNoteResponseDTO implements Comparable<GetNoteResponseDTO> {
     private Long noteId;
     private List<String> tags;
     private LocalDateTime created;
     private String rawMemo;
     private List<String> photos;
+
+    @Override
+    public int compareTo(GetNoteResponseDTO getNoteResponseDTO) {
+        if (this.getCreated().isAfter(getNoteResponseDTO.getCreated())) {
+            return -1;
+        } else if (this.getCreated() == getNoteResponseDTO.getCreated()) {
+            return 0;
+        } else {
+            return 1;
+        }
+    }
 }

--- a/src/main/java/com/poogle/phog/web/tag/controller/TagController.java
+++ b/src/main/java/com/poogle/phog/web/tag/controller/TagController.java
@@ -1,6 +1,7 @@
 package com.poogle.phog.web.tag.controller;
 
 import com.poogle.phog.service.TagService;
+import com.poogle.phog.web.note.dto.GetNoteResponseDTO;
 import com.poogle.phog.web.tag.dto.GetTagCategoryResponseDTO;
 import com.poogle.phog.web.tag.dto.GetTagListResponseDTO;
 import com.poogle.phog.web.tag.dto.PatchTagRequestDTO;
@@ -41,5 +42,11 @@ public class TagController {
     public List<GetTagCategoryResponseDTO> categorize(
             @RequestAttribute("id") Long userId, final Pageable pageable) {
         return tagService.tagCategoryResponseDTOList(userId, pageable);
+    }
+
+    @GetMapping("")
+    public List<GetNoteResponseDTO> taggedNotes(
+            @RequestParam(value = "tag", required = true) List<Long> tags) throws NotFound {
+        return tagService.getTaggedNoteList(tags);
     }
 }


### PR DESCRIPTION
### 구현 내용
* 태그 별 노트 목록(#TagName1, #TagName2, #TagName3) 구현
    * 태그는 최대 3개까지 다중 선택 가능 (백엔드 로직상 그 이상의 태그를 요청했을 때 응답은 가능한 상태)
    * 선택된 태그를 사용한 노트들을 중복없이 최신순으로 응답
    * 최신순으로 정렬하기 위해 compareTo 메서드를 override하고 Collection sort로 객체 배열 정렬

Close #22 