### PR TITLE
전체 예외처리 구현

### DIFF
--- a/src/main/java/com/poogle/phog/exception/AuthorizationException.java
+++ b/src/main/java/com/poogle/phog/exception/AuthorizationException.java
@@ -10,6 +10,10 @@ public class AuthorizationException extends RuntimeException {
         return new AuthorizationException("Token doesn't exist");
     }
 
+    public static AuthorizationException accessWrong() {
+        return new AuthorizationException("Not allowed access");
+    }
+
     public AuthorizationException(String message) {
         super(message);
     }

--- a/src/main/java/com/poogle/phog/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/poogle/phog/exception/GlobalExceptionHandler.java
@@ -11,7 +11,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(AuthorizationException.class)
     public ResponseEntity<String> handleAuthorizationException(RuntimeException e) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body("invalid token");
+                .body(e.getMessage());
     }
 
     @ExceptionHandler(VerificationException.class)
@@ -19,4 +19,11 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
                 .body(e.getMessage());
     }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<String> handleNotFoundException(RuntimeException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(e.getMessage());
+    }
+
 }

--- a/src/main/java/com/poogle/phog/exception/NotFoundException.java
+++ b/src/main/java/com/poogle/phog/exception/NotFoundException.java
@@ -1,0 +1,16 @@
+package com.poogle.phog.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class NotFoundException extends RuntimeException {
+
+    public static NotFoundException noteNotFound() {
+        return new NotFoundException("Note doesn't exist");
+    }
+
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/poogle/phog/service/NoteService.java
+++ b/src/main/java/com/poogle/phog/service/NoteService.java
@@ -164,7 +164,11 @@ public class NoteService {
         checkRemainTag(userId, note, newTags, dbTags);
     }
 
-    public void delete(Long noteId) {
+    public void delete(Long noteId, Long userId) {
+        Note note = noteRepository.findById(noteId).orElseThrow(() -> new NotFoundException("Note doesn't exist"));
+        if (!note.getUser().getId().equals(userId)) {
+            throw AuthorizationException.accessWrong();
+        }
         noteRepository.deleteById(noteId);
     }
 }

--- a/src/main/java/com/poogle/phog/service/NoteService.java
+++ b/src/main/java/com/poogle/phog/service/NoteService.java
@@ -50,6 +50,9 @@ public class NoteService {
         note.addPhotos(noteRequestDTO.getPhotos());
 
         List<String> newTags = note.captureTags(note);
+        if (newTags.isEmpty()) {
+            throw new VerificationException("There should be at least one tag");
+        }
         log.debug("[*] newTags : {}", newTags.toString());
         Map<String, Tag> dbTags = tagRepository.findTagsByUserIdAndTagNameIn(userId, newTags)
                 .stream()

--- a/src/main/java/com/poogle/phog/web/note/controller/NoteController.java
+++ b/src/main/java/com/poogle/phog/web/note/controller/NoteController.java
@@ -3,8 +3,8 @@ package com.poogle.phog.web.note.controller;
 import com.poogle.phog.domain.Note;
 import com.poogle.phog.domain.Photo;
 import com.poogle.phog.exception.AuthorizationException;
-import com.poogle.phog.exception.VerificationException;
 import com.poogle.phog.exception.NotFoundException;
+import com.poogle.phog.exception.VerificationException;
 import com.poogle.phog.service.NoteService;
 import com.poogle.phog.service.S3Service;
 import com.poogle.phog.web.note.dto.GetNoteResponseDTO;
@@ -91,8 +91,8 @@ public class NoteController {
 
     @DeleteMapping("/{note-id}")
     public void delete(@PathVariable(name = "note-id") Long noteId,
-                       HttpServletResponse response) {
-        noteService.delete(noteId);
+                       @RequestAttribute("id") Long userId, HttpServletResponse response) {
+        noteService.delete(noteId, userId);
         response.setStatus(HttpStatus.OK.value());
     }
 

--- a/src/main/java/com/poogle/phog/web/tag/controller/TagController.java
+++ b/src/main/java/com/poogle/phog/web/tag/controller/TagController.java
@@ -7,7 +7,6 @@ import com.poogle.phog.web.tag.dto.GetTagListResponseDTO;
 import com.poogle.phog.web.tag.dto.GetTagSuggestionDTO;
 import com.poogle.phog.web.tag.dto.PatchTagRequestDTO;
 import lombok.extern.slf4j.Slf4j;
-import org.omg.CosNaming.NamingContextPackage.NotFound;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -16,7 +15,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.util.List;
 
 @Slf4j
@@ -39,7 +37,7 @@ public class TagController {
     public void activate(@PathVariable(name = "tag-id") Long tagId,
                          @RequestBody PatchTagRequestDTO request,
                          @RequestAttribute("id") Long userId,
-                         HttpServletResponse response) throws NotFound {
+                         HttpServletResponse response) {
         tagService.changeActiveStatus(userId, tagId, request);
         response.setStatus(HttpStatus.OK.value());
     }
@@ -52,12 +50,12 @@ public class TagController {
 
     @GetMapping("")
     public List<GetNoteResponseDTO> taggedNotes(
-            @RequestParam(value = "tag", required = true) List<Long> tags) throws NotFound {
+            @RequestParam(value = "tag") List<Long> tags) {
         return tagService.getTaggedNoteList(tags);
     }
 
     @GetMapping(value = "/suggestion", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public GetTagSuggestionDTO suggest(@RequestPart("file") MultipartFile multipartFile) throws IOException, URISyntaxException {
+    public GetTagSuggestionDTO suggest(@RequestPart("file") MultipartFile multipartFile) throws IOException {
         return tagService.suggestTags(multipartFile);
     }
 }

--- a/src/main/java/com/poogle/phog/web/tag/controller/TagController.java
+++ b/src/main/java/com/poogle/phog/web/tag/controller/TagController.java
@@ -38,8 +38,9 @@ public class TagController {
     @PatchMapping("/{tag-id}")
     public void activate(@PathVariable(name = "tag-id") Long tagId,
                          @RequestBody PatchTagRequestDTO request,
+                         @RequestAttribute("id") Long userId,
                          HttpServletResponse response) throws NotFound {
-        tagService.changeActiveStatus(tagId, request);
+        tagService.changeActiveStatus(userId, tagId, request);
         response.setStatus(HttpStatus.OK.value());
     }
 


### PR DESCRIPTION
## 리팩토링 중 예외처리 전체 구현
* 관련 Issue #50 
* 참고사항
    * 요청으로 true, false 제외한 다른 문자열 -> 400 에러
    * 0, 1은 각각 false, true인데 그 외의 숫자 혹은 ""의 경우는 예외처리를 하지 못함(json에서 자동으로 boolean으로 인식하기 때문)
    * [Custom Serializer](https://www.baeldung.com/jackson-custom-serialization)의 방법이 있으나 적용하지 않기로 함

Closed #50 